### PR TITLE
Fixing the examples

### DIFF
--- a/examples/ajax/index.html
+++ b/examples/ajax/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: AJAX</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/annotating/index.html
+++ b/examples/annotating/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Adding Annotations</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/axes-interacting/index.html
+++ b/examples/axes-interacting/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Interacting with axes</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/axes-time-zones/index.html
+++ b/examples/axes-time-zones/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Time zones</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script language="javascript" type="text/javascript" src="date.js"></script>

--- a/examples/axes-time/index.html
+++ b/examples/axes-time/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Time Axes</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script type="text/javascript">

--- a/examples/basic-options/index.html
+++ b/examples/basic-options/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Basic Options</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/basic-usage/index.html
+++ b/examples/basic-usage/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Basic Usage</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Canvas text</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.canvas.js"></script>

--- a/examples/categories/index.html
+++ b/examples/categories/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Categories</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.categories.js"></script>
 	<script type="text/javascript">

--- a/examples/cursors/index.html
+++ b/examples/cursors/index.html
@@ -6,6 +6,8 @@
     <title>Flot Examples: Cursors</title>
     <link href="../examples.css" rel="stylesheet" type="text/css">
     <script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+    <script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+    <script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
     <script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
     <script language="javascript" type="text/javascript" src="../../jquery.flot.cursors.js"></script>
     <script type="text/javascript">

--- a/examples/image/index.html
+++ b/examples/image/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Image Plots</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.image.js"></script>
 	<script type="text/javascript">

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,6 +13,8 @@
 
 	</style>
 	<script language="javascript" type="text/javascript" src="../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../jquery.flot.js"></script>
 	<script type="text/javascript">
 
@@ -59,11 +61,13 @@
 		<ul>
 			<li><a href="symbols/index.html">Using other symbols than circles for points</a> (with symbol plugin)</li>
 			<li><a href="axes-time/index.html">Plotting time series</a>, <a href="visitors/index.html">visitors per day with zooming and weekends</a> (with selection plugin) and <a href="axes-time-zones/index.html">time zone support</a></li>
+			<li><a href="log-scale/index.html">Log scales</a></li>
 			<li><a href="axes-multiple/index.html">Multiple axes</a> and <a href="axes-interacting/index.html">interacting with the axes</a></li>
 			<li><a href="threshold/index.html">Thresholding the data</a> (with threshold plugin)</li>
 			<li><a href="stacking/index.html">Stacked charts</a> (with stacking plugin)</li>
 			<li><a href="percentiles/index.html">Using filled areas to plot percentiles</a> (with fillbetween plugin)</li>
 			<li><a href="tracking/index.html">Tracking curves with crosshair</a> (with crosshair plugin)</li>
+			<li><a href="cursors/index.html">Cursors</a> (with cursor plugin)</li>
 			<li><a href="image/index.html">Plotting prerendered images</a> (with image plugin)</li>
 			<li><a href="series-errorbars/index.html">Plotting error bars</a> (with errorbars plugin)</li>
 			<li><a href="series-pie/index.html">Pie charts</a> (with pie plugin)</li>

--- a/examples/interacting/index.html
+++ b/examples/interacting/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Interactivity</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/log-scale/index.html
+++ b/examples/log-scale/index.html
@@ -6,6 +6,8 @@
   <title>Flot Examples: Log Scale</title>
   <link href="../examples.css" rel="stylesheet" type="text/css">
   <script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+  <script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+  <script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
   <script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
   <script type="text/javascript">
     $(function () {

--- a/examples/percentiles/index.html
+++ b/examples/percentiles/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Percentiles</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.fillbetween.js"></script>
 	<script type="text/javascript">

--- a/examples/realtime/index.html
+++ b/examples/realtime/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Real-time updates</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/resize/index.html
+++ b/examples/resize/index.html
@@ -7,6 +7,8 @@
 	<link href="../shared/jquery-ui/jquery-ui.min.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
 	<script language="javascript" type="text/javascript" src="../shared/jquery-ui/jquery-ui.min.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.resize.js"></script>
 	<script type="text/javascript">

--- a/examples/selection/index.html
+++ b/examples/selection/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Selection</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.selection.js"></script>
 	<script type="text/javascript">

--- a/examples/series-errorbars/index.html
+++ b/examples/series-errorbars/index.html
@@ -5,8 +5,11 @@
 	<title>Flot Examples: Error Bars</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.errorbars.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.flot.uiConstants.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.navigate.js"></script>
 	<script type="text/javascript">
 

--- a/examples/series-pie/index.html
+++ b/examples/series-pie/index.html
@@ -76,6 +76,8 @@
 
 	</style>
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.pie.js"></script>
 	<script type="text/javascript">

--- a/examples/series-toggle/index.html
+++ b/examples/series-toggle/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Toggling Series</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/series-types/index.html
+++ b/examples/series-types/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Series Types</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script type="text/javascript">
 

--- a/examples/stacking/index.html
+++ b/examples/stacking/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Stacking</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.stack.js"></script>
 	<script type="text/javascript">

--- a/examples/symbols/index.html
+++ b/examples/symbols/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Symbols</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.symbol.js"></script>
 	<script type="text/javascript">

--- a/examples/threshold/index.html
+++ b/examples/threshold/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Thresholds</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.threshold.js"></script>
 	<script type="text/javascript">

--- a/examples/tracking/index.html
+++ b/examples/tracking/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Tracking</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.crosshair.js"></script>
 	<script type="text/javascript">

--- a/examples/visitors/index.html
+++ b/examples/visitors/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Visitors</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.time.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.selection.js"></script>

--- a/examples/zooming/index.html
+++ b/examples/zooming/index.html
@@ -5,6 +5,8 @@
 	<title>Flot Examples: Selection and zooming</title>
 	<link href="../examples.css" rel="stylesheet" type="text/css">
 	<script language="javascript" type="text/javascript" src="../../jquery.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.colorhelpers.js"></script>
+	<script language="javascript" type="text/javascript" src="../../jquery.canvaswrapper.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.js"></script>
 	<script language="javascript" type="text/javascript" src="../../jquery.flot.selection.js"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
(1) The missing log-scales and cursors examples were added to the main index.html file.

(2) These examples are still failing:

examples/axes-time/index.html
examples/visitors/index.html
examples/axes-time-zones/index.html
examples/axes-multiple/index.html
examples/canvas/index.html

because the axes have to write the time and by default there is no tickGenerator (anymore) that can handle the time.

(3) By default the grid is not drawn anymore. Each set of vertical or horizontal set of lines have to be requested in the options for each series when the graph is created. See this example that was previously updated: https://github.com/cipix2000/engineering-flot/blob/master/examples/interacting/index.html